### PR TITLE
Improve notice about no results

### DIFF
--- a/components/Content.tsx
+++ b/components/Content.tsx
@@ -319,9 +319,14 @@ export function Content({}) {
                 <span className="sr-only">Info</span>
                 <div>
                   <span className="font-medium">No results found.</span> Please
-                  double check for typos in the handle, and ensure that you
-                  follow at least a few people to seed the search. Otherwise,
-                  try again later as Mastodon may throttle requests.
+                  check for the following:<br>
+                  - Your handle has no typos and has the right format
+                  (username@domain.tld)<br>
+                  - You follow at least 1 account<br>
+                  - The option "Hide your social Graph" in your Profile
+                  Settings ("Settings" -&gt; "Profile") is <b>disabled</b><br>
+                  <br>
+                  Otherwise, try again later as Mastodon may throttle requests.
                 </div>
               </div>
             ) : null}


### PR DESCRIPTION
Mastodon allows in their settings to hide your social graph (aka. Hide who follows you and who you follow).
This isn't mentioned in the error message about no results, which also appears when you have your social graph hidden.

This PR improves the message to make it a bit more clear what to look for and also mentions the above feature.

I've tested it through dev tools and basic HTML editing. Result:
![grafik](https://github.com/gabipurcaru/followgraph/assets/11576465/99215570-b1fe-4f59-b9a6-6fd2c34e0991)

I first wanted to do unordered lists, but the CSS doesn't seem to support it now and my knowledge with next.js is too limited to make confident changes.